### PR TITLE
chore: upgrade to react-email 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,21 +13,20 @@
     "start": "next start"
   },
   "dependencies": {
-    "@react-email/components": "0.5.7",
+    "@react-email/ui": "6.0.0",
     "next": "16.0.3",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "resend": "latest"
   },
   "devDependencies": {
-    "@react-email/preview-server": "4.3.2",
     "@types/node": "24.10.1",
     "@types/react": "19.2.5",
     "@types/react-dom": "19.2.3",
     "eslint": "^9",
     "eslint-config-next": "16.0.3",
     "prettier": "3.2.5",
-    "react-email": "4.3.2",
+    "react-email": "6.0.0",
     "typescript": "5.8.3"
   },
   "overrides": {

--- a/transactional/emails/apple-receipt.tsx
+++ b/transactional/emails/apple-receipt.tsx
@@ -11,7 +11,7 @@ import {
   Row,
   Section,
   Text,
-} from '@react-email/components';
+} from 'react-email';
 import * as React from 'react';
 
 const baseUrl = process.env.VERCEL_URL

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Upgrades to [react-email 6](https://react.email/docs/getting-started/updating-react-email#update-from-react-email-5-0-to-6-0).

- Remove `@react-email/components` and `@react-email/preview-server`
- Add `react-email@6` and `@react-email/ui@6`
- Update import in `transactional/emails/apple-receipt.tsx` from `@react-email/components` to `react-email`
- Set `tsconfig.json` `moduleResolution` to `bundler` (required to resolve the new `react-email` package exports under Next 16)